### PR TITLE
Call function without using an if/else

### DIFF
--- a/sapporo/run.sh
+++ b/sapporo/run.sh
@@ -4,24 +4,13 @@ set -eu
 function run_wf() {
   echo "RUNNING" >${state}
   date +"%Y-%m-%dT%H:%M:%S" >${start_time}
-  if [[ ${wf_engine_name} == "cwltool" ]]; then
-    run_cwltool
+  # e.g. when wf_engine_name=cwltool, call function run_cwltool
+  local function_name="run_${wf_engine_name}"
+  if [[ "$(type -t ${function_name})" == "function" ]]; then
+    ${function_name}
     generate_outputs_list
-  elif [[ ${wf_engine_name} == "nextflow" ]]; then
-    run_nextflow
-    generate_outputs_list
-  elif [[ ${wf_engine_name} == "toil" ]]; then
-    run_toil
-    generate_outputs_list
-  elif [[ ${wf_engine_name} == "cromwell" ]]; then
-    run_cromwell
-    generate_outputs_list
-  elif [[ ${wf_engine_name} == "snakemake" ]]; then
-    run_snakemake
-    generate_outputs_list
-  elif [[ ${wf_engine_name} == "ep3" ]]; then
-    run_ep3
-    generate_outputs_list
+  else
+    executor_error
   fi
   upload
   date +"%Y-%m-%dT%H:%M:%S" >${end_time}


### PR DESCRIPTION
Hi!

I think in order to add another workflow engine, one of the steps would be to modify this `if/else`, adding a new condition for the new workflow engines.

I thought that list could end up getting quite long, so perhaps we could infer the function to call dynamically instead? This way I would only need to write the function `run_$name_of_engine` and it would automatically be invoked when the function name was passed… does this sound like a useful change?

My shell-fu is not really good so probably good to have a thorough review of what I changed. I tested running a simple hello world CWL workflow with `cwltool` + Sapporo.

Thanks
Bruno