### PR TITLE
fix(nextflow): propagate DOCKER_API_VERSION to fix Docker client version mismatch

### DIFF
--- a/sapporo/run.sh
+++ b/sapporo/run.sh
@@ -60,13 +60,21 @@ function run_cwltool() {
 
 function run_nextflow() {
     local container="nextflow/nextflow:25.10.4"
+    # Write a Nextflow config that propagates DOCKER_API_VERSION into child containers.
+    # This is required on Docker Desktop >= 4.x where the minimum supported API version
+    # is 1.44, but the Docker client bundled in nextflow/nextflow images reports 1.32.
+    local nf_config="${exe_dir}/sapporo.config"
+    cat > "${nf_config}" <<'NFCFG'
+docker.envWhitelist = 'DOCKER_API_VERSION'
+NFCFG
     local -a cmd_arr=(docker run --rm
         -v /var/run/docker.sock:/var/run/docker.sock
         -e DOCKER_HOST=unix:///var/run/docker.sock
+        -e DOCKER_API_VERSION=1.44
         -v "${run_dir}:${run_dir}"
         "-w=${exe_dir}"
         "${container}"
-        nextflow run "${wf_url}")
+        nextflow run "${wf_url}" -c "${nf_config}")
     _append_engine_params cmd_arr
     cmd_arr+=(-params-file "${wf_params}" --outdir "${outputs_dir}" -work-dir "${exe_dir}")
     _write_and_run cmd_arr


### PR DESCRIPTION
## Problem

When running nf-core pipelines via Sapporo on Docker Desktop >= 4.x, all Nextflow runs fail immediately with:

```
docker: Error response from daemon: client version 1.32 is too old.
Minimum supported API version is 1.44, please upgrade your client.
```

The Docker client bundled in `nextflow/nextflow` images reports API version 1.32, but Docker Desktop now requires a minimum of 1.44.

## Fix

1. Set `DOCKER_API_VERSION=1.44` in the Nextflow container environment — the Docker client reads this variable to override its reported API version.
2. Write a minimal `sapporo.config` with `docker.envWhitelist = 'DOCKER_API_VERSION'` so Nextflow propagates the variable into all child process containers spawned by the pipeline.

## Notes

- The same `DOCKER_API_VERSION=1.44` fix was already applied to `run_cwltool()`, `run_toil()`, `run_ep3()`, and `run_streamflow()` — this brings `run_nextflow()` in line with those.
- The `docker.envWhitelist` config is Nextflow-specific and needed because Nextflow does not pass host environment variables into child containers by default.
- Verified by running nf-core/fetchngs and nf-core/rnaseq end-to-end on macOS (Apple Silicon) with Docker Desktop 4.x.